### PR TITLE
Edit docs now working (to suggest edits), styling updates, add client-js and react dev tool docs

### DIFF
--- a/docs/developers/create-js-dapp.md
+++ b/docs/developers/create-js-dapp.md
@@ -240,7 +240,7 @@ const { data, error, loading } = useWeb3ApiQuery({
 });
 ```
 
-:::note
+:::tip
 By default, the `useWeb3ApiQuery` hook uses the first Web3ApiProvider found in the DOM's hierarchy. If you'd like to specify a specific provider to be used, simply set the `provider:` property:
 
 ```jsx

--- a/docs/devtools/clientjs.md
+++ b/docs/devtools/clientjs.md
@@ -1,0 +1,54 @@
+---
+id: web3api-clientjs
+title: '@web3api/client-js'
+---
+
+<a href="https://www.npmjs.com/package/@web3api/client-js" target="_blank" rel="noopener noreferrer">
+<img src="https://img.shields.io/npm/v/@web3api/client-js.svg" alt="npm"/>
+</a>
+
+<br/>
+<br/>
+
+The Web3API JavaScript client exists to help developers integrate Web3API into their applications. It's designed to run in any environment that can execute JavaScript (think websites, node scripts, etc.).
+
+## Installation
+
+```bash
+npm i @web3api/client-js
+```
+
+## Usage
+
+Use an `import` or `require` statement, depending on which your environment supports.
+
+```js
+import { Web3APIClient } from '@web3api/client-js';
+```
+
+Then, you will be able to use the `Web3APIClient` like so:
+
+```js
+async function main() {
+  // Simply instantiate the Web3APIClient.
+  const client = new Web3APIClient();
+
+  // ...And then you'll be able to use the `query`
+  // method to send GraphQL requests to any Web3API
+  // that's located at the specified URI.
+  const result = await client.query({
+    uri: 'api.example.eth',
+    query: `query {
+      doSomething(
+        variable: $variable
+        value: "important value"
+      ) {
+        returnData
+      }
+    }`,
+    variables: {
+      variable: 555,
+    },
+  });
+}
+```

--- a/docs/devtools/clientjs.md
+++ b/docs/devtools/clientjs.md
@@ -15,7 +15,7 @@ The Web3API JavaScript client exists to help developers integrate Web3API into t
 ## Installation
 
 ```bash
-npm i @web3api/client-js
+npm install @web3api/client-js
 ```
 
 ## Usage

--- a/docs/devtools/react.md
+++ b/docs/devtools/react.md
@@ -1,0 +1,89 @@
+---
+id: web3api-react
+title: '@web3api/react'
+---
+
+<a href="https://www.npmjs.com/package/@web3api/react" target="_blank" rel="noopener noreferrer">
+<img src="https://img.shields.io/npm/v/@web3api/react.svg" alt="npm"/>
+</a>
+
+<br/>
+<br/>
+
+The purpose of the Web3API React library is to simplify integration of Web3API into React applications.
+
+## Installation
+
+```bash
+npm install @web3api/client-js
+```
+
+## Usage
+
+### Web3ApiProvider
+
+To start using the Web3API React library, wrap your application in a `Web3ApiProvider`:
+
+```typescript
+import React from 'react';
+import { Web3ApiProvider } from '@web3api/react';
+
+export default function App() {
+  return (
+    <Web3ApiProvider>
+      <div>{'Web3API enabled dApp goes here!'}</div>
+    </Web3ApiProvider>
+  );
+}
+```
+
+The `Web3ApiProvider` instantiates the `Web3ApiClient` for all queries below it in the component tree.
+
+The `Web3ApiProvider` also accepts URI redirects as props. For more information on URI redirects, please take a look at this section in our [Create a JS dApp guide](http://localhost:3000/developers/create-js-dapp#understanding-uris).
+
+You can pass the redirects array into the provider component like so:
+
+```typescript
+<Web3ApiProvider redirects={ [...] }/>
+```
+
+If you need to use multiple providers, you can do so using the `createWeb3ApiProvider("...")` method, which accepts the name of your provider as an argument. For example:
+
+```typescript
+import { createWeb3ApiProvider } from '@web3api/react';
+
+const CustomWeb3ApiProvider = createWeb3ApiProvider('custom');
+
+<CustomWeb3ApiProvider>
+  <Custom />
+</CustomWeb3ApiProvider>;
+```
+
+### useWeb3ApiQuery
+
+The `useWeb3ApiQuery` is the primary API for executing queries. To run a query within a React component, call `useWeb3ApiQuery` and pass it a GraphQL query string. When your component renders, `useWeb3ApiQuery` returns an object from the Web3API client that contains `data`, `loading`, and `error` properties you can use to render your UI.
+
+Here's an example query that you could send:
+
+```typescript
+import { useWeb3ApiQuery } from '@web3api/react';
+
+const { data, error, loading } = useWeb3ApiQuery({
+  uri: 'ens/api.helloworld.web3api.eth',
+  query: `{
+    logMessage(message: "Hello World!")
+  }`,
+});
+```
+
+:::tip
+By default, the `useWeb3ApiQuery` hook uses the first `Web3ApiProvider` found in the DOM's hierarchy. If you'd like to specify a specific provider to be used, simply set the provider: property:
+
+```typescript
+useWeb3ApiQuery({
+  provider: 'custom',
+  ...
+});
+```
+
+:::

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -8,6 +8,7 @@ slug: /
 **Web3API** is a developer toolchain that makes it easy to interact with any blockchain (or P2P network) from any programming language!
 
 :::caution
+
 Web3API is in **pre-alpha**, meaning our code and documentation are rapidly changing. Have questions or want to get involved? Join our [Discord](https://discord.com/invite/Z5m88a5qWu) or [open an issue](https://github.com/Web3-API/monorepo/issues) on our GitHub repo.
 
 :::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',
   organizationName: 'web3-api',
-  projectName: 'monorepo',
+  projectName: 'documentation',
   themeConfig: {
     sidebarCollapsible: false,
     colorMode: {
@@ -105,7 +105,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/web3-api/monorepo',
+          editUrl: 'https://github.com/web3-api/documentation/tree/main',
           routeBasePath: '/',
         },
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,6 +21,7 @@ module.exports = {
   organizationName: 'web3-api',
   projectName: 'monorepo',
   themeConfig: {
+    sidebarCollapsible: false,
     colorMode: {
       defaultMode: 'dark',
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -22,14 +22,13 @@ module.exports = {
     {
       type: 'category',
       label: 'Developer Tools',
-      items: ['devtools/web3api-cli'],
+      items: ['devtools/web3api-cli', 'devtools/web3api-clientjs'],
     },
     {
       type: 'category',
       label: 'Resources',
       items: [
         'resources/talks-and-videos',
-        'resources/developer-tooling',
         'resources/the-web3api-technical-standard',
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -22,7 +22,11 @@ module.exports = {
     {
       type: 'category',
       label: 'Developer Tools',
-      items: ['devtools/web3api-cli', 'devtools/web3api-clientjs'],
+      items: [
+        'devtools/web3api-cli',
+        'devtools/web3api-clientjs',
+        'devtools/web3api-react',
+      ],
     },
     {
       type: 'category',

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /* stylelint-disable docusaurus/copyright-header */
 /**
  * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
+ * bundles Infima by defaula. Infima is a CSS framework designed to
  * work well for content-centric websites.
  */
 
@@ -24,18 +24,43 @@
   --ifm-background-color: #f7f8fa;
   --ifm-navbar-background-color: #f7f8fa;
 }
+/* General styling */
+h2 {
+  font-size: 1.65rem;
+}
 
+body {
+  background-image: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(33, 114, 229, 0.1) 0%,
+    rgba(33, 36, 41, 0) 100%
+  );
+}
+
+html[data-theme='dark'] {
+  --ifm-background-color: #243037;
+  --ifm-navbar-background-color: rgb(28, 39, 45);
+  --ifm-blockquote-color: #d8d8d8;
+}
+
+/* Sidebar */
+.menuLinkText_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocSidebar- {
+  font-weight: 600;
+}
+
+table tr {
+  background: transparent;
+}
+
+/* Admonition */
 html[data-theme='dark'] {
   --ifm-alert-color: #f7f8fa;
   --ifm-color-gray-900: #529dad;
 }
 
-.admonition {
-  border-radius: 0;
-}
-
 .alert {
   background-color: transparent;
+  border-radius: 0;
   border-width: 0;
 }
 
@@ -55,26 +80,9 @@ html[data-theme='dark'] {
   font-size: 2.3rem !important;
 }
 
+/* Table of contents */
 .table-of-contents {
   font-size: 0.75rem;
-}
-
-h2 {
-  font-size: 1.65rem;
-}
-
-body {
-  background-image: radial-gradient(
-    50% 50% at 50% 50%,
-    rgba(33, 114, 229, 0.1) 0%,
-    rgba(33, 36, 41, 0) 100%
-  );
-}
-
-html[data-theme='dark'] {
-  --ifm-background-color: #243037;
-  --ifm-navbar-background-color: rgb(28, 39, 45);
-  --ifm-blockquote-color: #d8d8d8;
 }
 
 .docusaurus-highlight-code-line {

--- a/style.css
+++ b/style.css
@@ -25,6 +25,32 @@
   --ifm-navbar-background-color: #f7f8fa;
 }
 
+html[data-theme='dark'] {
+  --ifm-alert-color: #f7f8fa;
+  --ifm-color-gray-900: #529dad;
+}
+
+.admonition {
+  border-radius: 0;
+}
+
+.alert {
+  background-color: transparent;
+  border-width: 0;
+}
+
+.alert--warning {
+  border-left: 0.5rem solid #ffef62;
+}
+
+.alert--success {
+  border-left: 0.5rem solid #00a400;
+}
+
+.alert--danger {
+  border-left: 0.5rem solid #fa383e;
+}
+
 .docTitle_node_modules-\@docusaurus-theme-classic-lib-next-theme-DocItem- {
   font-size: 2.3rem !important;
 }


### PR DESCRIPTION
## Features added
- "Edit this page" links now send readers to the correct Github page so they can suggest edits.

## Styling
- Sidebar now shows all links by default:

<img width="301" alt="Screen Shot 2021-05-07 at 9 42 16 PM" src="https://user-images.githubusercontent.com/69411313/117526961-2adf9280-af7d-11eb-9056-4c4cae4ee270.png">

- Style admonitions to be more subtle (they were too distracting before):

<img width="838" alt="Screen Shot 2021-05-07 at 9 43 53 PM" src="https://user-images.githubusercontent.com/69411313/117526991-55c9e680-af7d-11eb-9c28-951e726a5a9b.png">

## Docs added
- `devtools`: client-js and react
